### PR TITLE
Use `github` flavor

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -17,6 +17,7 @@ export default class MarkdownToHTML extends Plugin {
 
 		markdownToHTML(editor: Editor) {
 			const converter = new showdown.Converter();
+			converter.setFlavor('github');
 			let text = editor.getSelection();
 			let noBrackets = text.replace(/\[\[(?:[^\]]+\|)?([^\]]+)\]\]/g, '$1');
 			let html = converter.makeHtml(noBrackets).toString();


### PR DESCRIPTION
Configures the usage of `showdown` to use it's `github` preconfiguration. This would enable a standard set of "extended" markdown syntax that's expected by more users over Gruber's original usage.

This would add rendering of tables, strikedown, fix tasks, simple line breaks, etc.

Likely resolves #1