### PR TITLE
added command for text conversion

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -10,34 +10,49 @@ export default class MarkdownToHTML extends Plugin {
 		this.addCommand({
 			id: 'copy-as-html-command',
 			name: 'Copy as HTML command',
-			editorCallback: (editor: any) => this.markdownToHTML(editor)
+			editorCallback: (editor: any) => this.convertMarkdown(editor, false)
 		});
 
-		}
+		this.addCommand({
+			id: 'copy-as-text-command',
+			name: 'Copy as text command',
+			editorCallback: (editor: any) => this.convertMarkdown(editor, true)
+		});
 
-		markdownToHTML(editor: Editor) {
-			const converter = new showdown.Converter();
-			let text = editor.getSelection();
-			let noBrackets = text.replace(/\[\[(?:[^\]]+\|)?([^\]]+)\]\]/g, '$1');
-			let html = converter.makeHtml(noBrackets).toString();
-			const withDivWrapper = `<!-- directives:[] -->
-			<div id="content">${html}</div>`;
-			//@ts-ignore
-			const blob = new Blob([withDivWrapper], {
-				//@ts-ignore
-				type: ["text/plain", "text/html"]
-			  })
-			const data = [new ClipboardItem({
-				//@ts-ignore
-				["text/plain"]: blob,
-				//@ts-ignore
-				["text/html"]: blob
-			  })];
-			//@ts-ignore
-			navigator.clipboard.write(data);
-		}
-
-		onunload() {
-	
-		}
 	}
+
+	convertMarkdown(editor: Editor, convertToText: boolean) {
+		const converter = new showdown.Converter();
+		let text = editor.getSelection() ? editor.getSelection() : editor.getLine(editor.getCursor().line);
+		let noBrackets = text.replace(/\[\[(?:[^\]]+\|)?([^\]]+)\]\]/g, '$1');
+		const html = converter.makeHtml(noBrackets).toString();
+
+		let convertedContent;
+		if(convertToText) {
+			const div = document.createElement("div");
+    		div.innerHTML = html;
+			convertedContent = div.textContent;
+		} else {
+			convertedContent = `<!-- directives:[] -->
+			<div id="content">${html}</div>`;
+		}
+
+		//@ts-ignore
+		const blob = new Blob([convertedContent], {
+			//@ts-ignore
+			type: ["text/plain", "text/html"]
+			})
+		const data = [new ClipboardItem({
+			//@ts-ignore
+			["text/plain"]: blob,
+			//@ts-ignore
+			["text/html"]: blob
+			})];
+		//@ts-ignore
+		navigator.clipboard.write(data);
+	}
+
+	onunload() {
+
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"id": "copy-as-html",
-	"name": "Copy as HTML",
+	"name": "Copy as HTML / Text",
 	"version": "1.0.5",
 	"minAppVersion": "0.12.0",
-	"description": "This is a simple plugin that converts the selected markdown to HTML and copies it to the clipboard.",
+	"description": "This is a simple plugin that converts the selected markdown to HTML or plain text and copies it to the clipboard.",
 	"author": "Bailey Jennings",
 	"authorUrl": "https://twitter.com/Bailey_Jennings",
 	"isDesktopOnly": false


### PR DESCRIPTION
Hi! I was looking for a plugin that would allow me to copy plain text from the editor easily, and yours was the closest one I found, so I added a command for copying just text. I also added the default funcionality that if no text is selected, it uses the line you are positioned at. I'm sending the PR just to share the idea, I'm sure the implementation can be improved.