### PR TITLE
Added features UTF-8 arrows and Anki-Mathjax

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -41,7 +41,6 @@ export default class MarkdownToHTML extends Plugin {
         if (this.settings.removeBrackets) {
             text = text.replace(/\[\[(.*?)\]\]/g, '$1');
           }
-          
         if (this.settings.removeEmphasis) {
             text = text.replace(/[*~]+(\w+)[*~]+/g, '$1');
           }
@@ -53,6 +52,14 @@ export default class MarkdownToHTML extends Plugin {
         if (this.settings.removeComments) {
             text = text.replace(/%%.+%%/g, '');
           }
+        if (this.settings.convertArrows) {
+    	text = text.replace(/(?<!<)->/g, '&rarr;');
+    	text = text.replace(/<-(?!>)/g, '&larr;');
+    	text = text.replace(/<->/g, '&harr;');
+    	text = text.replace(/(?<!<)=>/g, '&rArr;');
+    	text = text.replace(/<=>/g, '&hArr;');
+	  }  
+          
         const html = converter.makeHtml(text).toString();
         const withDivWrapper = `<!-- directives:[] -->
             <div id="content">${html}</div>`;
@@ -145,7 +152,7 @@ class MarkdownToHTMLSettingTab extends PluginSettingTab {
         .addToggle(toggle => toggle
           .setValue(this.plugin.settings.convertArrows)
           .onChange(async (value) => {
-            this.plugin.settings.removeTags = value;
+            this.plugin.settings.convertArrows = value;
             await this.plugin.saveSettings();
           }));  
 

--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ interface MarkdownToHTMLSettings {
     removeEmphasis: boolean;
     removeTags: boolean;
     removeComments: boolean;
+    convertArrows: boolean;
   }
   
 
@@ -13,7 +14,8 @@ interface MarkdownToHTMLSettings {
     removeBrackets: true,
     removeEmphasis: false,
     removeTags: false,
-    removeComments: false
+    removeComments: false,
+    convertArrows: false
   };
 
 export default class MarkdownToHTML extends Plugin {
@@ -136,6 +138,17 @@ class MarkdownToHTMLSettingTab extends PluginSettingTab {
             this.plugin.settings.removeComments = value;
             await this.plugin.saveSettings();
           }));
+          
+        new Setting(containerEl)
+        .setName("Convert Arrows")
+        .setDesc("If enabled, converts ASCII Arrows to UTF-8")
+        .addToggle(toggle => toggle
+          .setValue(this.plugin.settings.convertArrows)
+          .onChange(async (value) => {
+            this.plugin.settings.removeTags = value;
+            await this.plugin.saveSettings();
+          }));  
+
     }
   }
   

--- a/main.ts
+++ b/main.ts
@@ -147,8 +147,8 @@ class MarkdownToHTMLSettingTab extends PluginSettingTab {
           }));
           
         new Setting(containerEl)
-        .setName("Convert Arrows")
-        .setDesc("If enabled, converts ASCII Arrows to UTF-8")
+        .setName("Convert arrows")
+        .setDesc("If enabled, converts ASCII arrows to UTF-8 arrows")
         .addToggle(toggle => toggle
           .setValue(this.plugin.settings.convertArrows)
           .onChange(async (value) => {


### PR DESCRIPTION
Hey I added two features to your addon. 
1. UTF-8 Arrows
- I really like that ASCII arrows such as -> get displayed as → in Obsidian and thus use them quite frequently. 
- I added an optional regex to replace these arrows when converting to HTML
2. Anki MathJax
- I mostly use your Plugin to convert notes to flashcards for the [Anki](https://github.com/ankitects/anki) flashcard app, which uses a different notation to display MathJax 
- I added an optional regex to replace the  MathJax indicators `$` and `$$` with the `<anki-mathjax>` tag used by Anki.

⇒ Hope these changes are beneficial and feel free to leave any commentary. (I am quite new to scripting) 